### PR TITLE
TP2000-1492  Resolve Dependabot alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,5 +19,5 @@ gem 'rake'
 
 gem "sqlite3", "~> 1.6"
 
-gem "nokogiri", ">= 1.15.6"
+gem "nokogiri", ">= 1.16.7"
 gem "rack", ">= 2.2.8.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,9 +128,9 @@ GEM
       rouge (~> 3.2)
     minitest (5.22.3)
     multi_json (1.15.0)
-    nokogiri (1.16.4-x86_64-darwin)
+    nokogiri (1.16.7-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.16.4-x86_64-linux)
+    nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     openapi3_parser (0.9.2)
       commonmarker (~> 0.17)
@@ -142,7 +142,7 @@ GEM
     parallel (1.24.0)
     parslet (2.0.0)
     public_suffix (5.0.5)
-    racc (1.7.3)
+    racc (1.8.1)
     rack (2.2.9)
     rack-livereload (0.3.17)
       rack
@@ -176,12 +176,13 @@ GEM
 
 PLATFORMS
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   dbml (>= 0.2)
   govuk_tech_docs (~> 3.3)
-  nokogiri (>= 1.15.6)
+  nokogiri (>= 1.16.7)
   rack (>= 2.2.8.1)
   rake
   sqlite3 (~> 1.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,7 +151,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.1)
-    rexml (3.2.6)
+    rexml (3.3.7)
     rouge (3.30.0)
     rsec (1.0.0)
     sass (3.4.25)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Requires:
 
 * graphviz
 * node (supported major versions: 10, 12, 14)
-* ruby 2.7.2
+* ruby 3.2.0
 
 On Mac these can be installed with:
 


### PR DESCRIPTION
# [TP2000-1492](https://uktrade.atlassian.net/browse/TP2000-1492) Resolve Dependabot alerts

- Bumps `nokogiri` from 1.15.6 to 1.16.7
- Bumps `rexml` from 3.2.6 to 3.3.7
- Amends ruby version in README to match the specified version in `.ruby-version` (3.2.0)

[TP2000-1492]: https://uktrade.atlassian.net/browse/TP2000-1492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ