### PR TITLE
TP2000-1527 Bump webrick from 1.8.1 to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,7 +172,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
-    webrick (1.8.1)
+    webrick (1.8.2)
 
 PLATFORMS
   x86_64-darwin-22


### PR DESCRIPTION
# [TP2000-1527](https://uktrade.atlassian.net/browse/TP2000-1527) Bump webrick from 1.8.1 to 1.8.2

- Bumps `webrick` from 1.8.1 to 1.8.2 to resolve Dependabot alert

[TP2000-1527]: https://uktrade.atlassian.net/browse/TP2000-1527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ